### PR TITLE
feat: wal flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ defmodule ExampleApp.Application do
           database: "yourdb",
           password: "yourpassword"
         },
+        # optional, function to fetch the current wal lsn if you want to avoid creating a new postgres connection each time it is flushed
+        fetch_current_wal_lsn: fn -> {:ok, {0, 0}} end,
+        # optional, defaults to 5_000 (5s)
+        wal_flush_timeout: 15_000,
         slot: "example", # :temporary is also supported if you don't want Postgres keeping track of what you've acknowledged
         wal_position: {"0", "0"}, # You can provide a different WAL position if desired, or default to allowing Postgres to send you what it thinks you need
         publications: ["example_publication"]

--- a/lib/cainophile/adapters/postgres/adapter_behavior.ex
+++ b/lib/cainophile/adapters/postgres/adapter_behavior.ex
@@ -4,5 +4,8 @@ defmodule Cainophile.Adapters.Postgres.AdapterBehaviour do
 
   @callback acknowledge_lsn(connection :: pid, {xlog :: integer, offset :: integer}) :: :ok
 
+  @callback fetch_current_wal_lsn(config :: term) ::
+              {:ok, {xlog :: integer, offset :: integer}} | {:error, term}
+
   @callback cleanup(connection :: pid) :: :ok
 end


### PR DESCRIPTION
This PR implements retained wal flushing by updating the standby status periodically to the latest in the event that there is inactivity in subscriptions.
This PR closes https://github.com/Logflare/logflare/issues/2375 , as replication slot will gradually build up over time as other tables are changed.
